### PR TITLE
fix(ai): normalize OpenAI-compatible base URLs for local endpoints

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -92,6 +92,7 @@ func (c *Client) RequestWithMessages(messages []map[string]string) (ResponseResu
 // RequestWithConfig makes an AI request with full configuration
 func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error) {
 	provider := DetectAPIProvider(c.config.Endpoint)
+	var lastErr error
 
 	// Try provider-specific format first based on endpoint detection
 	switch provider {
@@ -100,6 +101,7 @@ func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error)
 		if err == nil {
 			return result, nil
 		}
+		lastErr = err
 		// Fall through to other formats
 
 	case "anthropic":
@@ -107,6 +109,7 @@ func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error)
 		if err == nil {
 			return result, nil
 		}
+		lastErr = err
 		// Fall through to other formats
 
 	case "deepseek":
@@ -114,6 +117,7 @@ func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error)
 		if err == nil {
 			return result, nil
 		}
+		lastErr = err
 		// Fall through to other formats
 
 	case "ollama":
@@ -121,6 +125,7 @@ func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error)
 		if err == nil {
 			return result, nil
 		}
+		lastErr = err
 		// Fall through to other formats
 	}
 
@@ -129,6 +134,7 @@ func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error)
 	if err == nil {
 		return result, nil
 	}
+	lastErr = err
 
 	// Try other formats as fallback
 	if provider != "gemini" {
@@ -136,6 +142,7 @@ func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error)
 		if err == nil {
 			return result, nil
 		}
+		lastErr = err
 	}
 
 	if provider != "ollama" {
@@ -143,9 +150,13 @@ func (c *Client) RequestWithConfig(config RequestConfig) (ResponseResult, error)
 		if err == nil {
 			return result, nil
 		}
+		lastErr = err
 	}
 
-	// All formats failed
+	// All formats failed — surface the last error for troubleshooting
+	if lastErr != nil {
+		return ResponseResult{}, fmt.Errorf("all API formats failed: %w", lastErr)
+	}
 	return ResponseResult{}, fmt.Errorf("all API formats failed")
 }
 

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -143,9 +144,40 @@ func (h *OpenAIHandler) ValidateResponse(statusCode int, body []byte) error {
 	}
 }
 
-// FormatEndpoint returns the endpoint as-is for OpenAI format
+// FormatEndpoint normalizes OpenAI-compatible base URLs to the chat completions path.
+// Many local servers (llama.cpp, vLLM, LocalAI, Ollama OpenAI mode) document the base
+// as http://host:port/v1; the actual POST target is /v1/chat/completions.
 func (h *OpenAIHandler) FormatEndpoint(endpoint, model string) string {
-	return strings.TrimSuffix(endpoint, "/")
+	if endpoint == "" {
+		return "https://api.openai.com/v1/chat/completions"
+	}
+
+	endpoint = strings.TrimSuffix(endpoint, "/")
+	parsedURL, err := url.Parse(endpoint)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return endpoint
+	}
+
+	path := strings.TrimSuffix(parsedURL.Path, "/")
+	switch path {
+	case "", "/v1":
+		parsedURL.Path = "/v1/chat/completions"
+		return parsedURL.String()
+	case "/v1/chat/completions":
+		return parsedURL.String()
+	default:
+		// If the path already ends with chat/completions (or a custom gateway route), keep it.
+		if strings.HasSuffix(path, "/chat/completions") {
+			return parsedURL.String()
+		}
+		// Common OpenAI-compatible base: .../compatible-mode/v1, .../openai/v1, etc.
+		if strings.HasSuffix(path, "/v1") {
+			parsedURL.Path = path + "/chat/completions"
+			return parsedURL.String()
+		}
+		// Full custom paths are used as-is.
+		return endpoint
+	}
 }
 
 // IsOpenAIError checks if an error message indicates an OpenAI API format

--- a/internal/ai/openai_endpoint_test.go
+++ b/internal/ai/openai_endpoint_test.go
@@ -1,0 +1,57 @@
+package ai
+
+import "testing"
+
+func TestOpenAIFormatEndpointNormalizesBaseURLs(t *testing.T) {
+	handler := NewOpenAIHandler()
+
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{
+			name:     "empty defaults to openai",
+			endpoint: "",
+			want:     "https://api.openai.com/v1/chat/completions",
+		},
+		{
+			name:     "host only",
+			endpoint: "http://10.0.1.4:8080",
+			want:     "http://10.0.1.4:8080/v1/chat/completions",
+		},
+		{
+			name:     "v1 base path",
+			endpoint: "http://10.0.1.4:8080/v1",
+			want:     "http://10.0.1.4:8080/v1/chat/completions",
+		},
+		{
+			name:     "v1 with trailing slash",
+			endpoint: "http://10.0.1.4:8080/v1/",
+			want:     "http://10.0.1.4:8080/v1/chat/completions",
+		},
+		{
+			name:     "full chat completions path",
+			endpoint: "http://10.0.1.4:8080/v1/chat/completions",
+			want:     "http://10.0.1.4:8080/v1/chat/completions",
+		},
+		{
+			name:     "compatible mode v1",
+			endpoint: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+			want:     "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
+		},
+		{
+			name:     "custom gateway path kept",
+			endpoint: "https://gateway.example.com/proxy/openai",
+			want:     "https://gateway.example.com/proxy/openai",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := handler.FormatEndpoint(tt.endpoint, "qwen-local"); got != tt.want {
+				t.Fatalf("FormatEndpoint(%q) = %q, want %q", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Normalize OpenAI-compatible endpoint bases (`http://host:port`, `.../v1`, `.../compatible-mode/v1`) to `.../chat/completions`
- Fixes local model test failures when users configure the common base URL (e.g. `http://10.0.1.4:8080/v1`) instead of the full chat path
- Surface the last underlying error when all API format attempts fail, instead of only `all API formats failed`
- Add unit tests for endpoint normalization

## Context
Local OpenAI-compatible servers (llama.cpp, vLLM, LocalAI) document base URLs as `http://host:port/v1`. MrRSS previously POSTed to that path as-is (404), while the working path is `/v1/chat/completions`. DeepSeek already had similar normalization; OpenAI format did not.

## Test plan
- [x] `go test ./internal/ai/ -count=1`
- [ ] Configure AI profile with endpoint `http://<local>:8080/v1` and model name from the local server
- [ ] Click test — expect success against `/v1/chat/completions`
- [ ] Configure full path `.../v1/chat/completions` — still works (no double-append)
- [ ] Cloud OpenAI/DeepSeek/Gemini endpoints still work as before